### PR TITLE
fix: Correct COP calculation in cooling mode and add minimum power th…

### DIFF
--- a/custom_components/ha_daikin_altherma4_modbus/sensor.py
+++ b/custom_components/ha_daikin_altherma4_modbus/sensor.py
@@ -275,7 +275,11 @@ def calculate_thermal_heat_output(coordinator):
     temp_rl = temp_rl_raw  # °C
 
     delta_t = temp_vl - temp_rl
-    thermal_heat_output = flow * delta_t * 70  # Berechnung thermische Leistung in W
+    # Use absolute value to correctly calculate thermal power in both heating
+    # (vl > rl) and cooling (vl < rl) mode
+    thermal_heat_output = (
+        flow * abs(delta_t) * 70
+    )  # Berechnung thermische Leistung in W
     _LOGGER.debug(f"flow: {flow} L/min")
     _LOGGER.debug(f"delta_t: {delta_t} K")
     _LOGGER.debug(f"thermal_heat_output: {thermal_heat_output} W")
@@ -388,8 +392,9 @@ class CalculatedCoPSensor(CoordinatorEntity, SensorEntity):
             # Convert kW to W for consistent calculation
             electric_power = electric_power * 1000
 
-        if electric_power and electric_power > 0 and heat_power > 0:
+        if electric_power is not None and electric_power >= 150 and heat_power > 0:
             # Beide Leistungen in W, direkte Berechnung
+            # Minimum power threshold of 150 W ensures pump is actively running
             cop = heat_power / electric_power
             return round(cop, 2)
         else:

--- a/tests/test_cop_sensor.py
+++ b/tests/test_cop_sensor.py
@@ -623,3 +623,109 @@ def test_cop_sensor_with_legacy_entry_data(monkeypatch):
 
     # heat_power = 3500W, electric_power = 500W -> CoP = 7.0
     assert sensor.native_value == 7.0
+
+
+def test_cop_sensor_returns_none_when_electric_power_below_threshold(monkeypatch):
+    """Test that CoP returns None when electric power is below 150W threshold."""
+    sensor_module = _load_sensor_module(monkeypatch)
+
+    states = {
+        "sensor.external_power": SimpleNamespace(
+            state="100", attributes={"unit_of_measurement": "W"}
+        ),
+    }
+    hass = SimpleNamespace(
+        states=SimpleNamespace(get=lambda entity_id: states.get(entity_id))
+    )
+
+    coordinator = SimpleNamespace(
+        hass=hass,
+        data={
+            "input_49": {"value": 10.0},  # Flow = 10 L/min
+            "input_40": {"value": 45.0},  # Vorlauf = 45°C
+            "input_42": {"value": 40.0},  # Rücklauf = 40°C
+        },
+    )
+
+    sensor = sensor_module.CalculatedCoPSensor(
+        coordinator=coordinator,
+        entry=SimpleNamespace(
+            data={}, options={"electric_power_sensor": "sensor.external_power"}
+        ),
+        unique_id="cop",
+        unit="CoP",
+        device_class=None,
+    )
+
+    # heat_power = 3500W, electric_power = 100W (< 150W) -> should return None
+    assert sensor.native_value is None
+
+
+def test_cop_sensor_cooling_mode_negative_delta_t(monkeypatch):
+    """Test CoP calculation in cooling mode where Vorlauf < Rücklauf (negative delta_t)."""
+    sensor_module = _load_sensor_module(monkeypatch)
+
+    states = {
+        "sensor.external_power": SimpleNamespace(
+            state="800", attributes={"unit_of_measurement": "W"}
+        ),
+    }
+    hass = SimpleNamespace(
+        states=SimpleNamespace(get=lambda entity_id: states.get(entity_id))
+    )
+
+    # Cooling mode: Vorlauf (7°C) < Rücklauf (12°C) -> delta_t = -5K
+    coordinator = SimpleNamespace(
+        hass=hass,
+        data={
+            "input_49": {"value": 10.0},  # Flow = 10 L/min
+            "input_40": {"value": 7.0},  # Vorlauf = 7°C (kalt)
+            "input_42": {"value": 12.0},  # Rücklauf = 12°C (warm)
+        },
+    )
+
+    sensor = sensor_module.CalculatedCoPSensor(
+        coordinator=coordinator,
+        entry=SimpleNamespace(
+            data={}, options={"electric_power_sensor": "sensor.external_power"}
+        ),
+        unique_id="cop",
+        unit="CoP",
+        device_class=None,
+    )
+
+    # heat_power = 10 * abs(7 - 12) * 70 = 10 * 5 * 70 = 3500W
+    # electric_power = 800W
+    # CoP = 3500 / 800 = 4.375 -> rounded to 4.38
+    assert sensor.native_value == 4.38
+
+
+def test_cop_sensor_cooling_mode_with_modbus_power(monkeypatch):
+    """Test CoP calculation in cooling mode using Modbus power data."""
+    sensor_module = _load_sensor_module(monkeypatch)
+
+    hass = SimpleNamespace(states=SimpleNamespace(get=lambda entity_id: None))
+
+    # Cooling mode: Vorlauf (8°C) < Rücklauf (14°C) -> delta_t = -6K
+    coordinator = SimpleNamespace(
+        hass=hass,
+        data={
+            "input_49": {"value": 8.0},  # Flow = 8 L/min
+            "input_40": {"value": 8.0},  # Vorlauf = 8°C
+            "input_42": {"value": 14.0},  # Rücklauf = 14°C
+            "input_51": {"value": 0.72},  # Power = 0.72 kW = 720W
+        },
+    )
+
+    sensor = sensor_module.CalculatedCoPSensor(
+        coordinator=coordinator,
+        entry=SimpleNamespace(data={}, options={}),
+        unique_id="cop",
+        unit="CoP",
+        device_class=None,
+    )
+
+    # heat_power = 8 * abs(8 - 14) * 70 = 8 * 6 * 70 = 3360W
+    # electric_power = 720W
+    # CoP = 3360 / 720 = 4.666... -> rounded to 4.67
+    assert sensor.native_value == 4.67


### PR DESCRIPTION
fix: Correct COP calculation in cooling mode and add minimum power threshold

- Fix thermal power calculation using abs(delta_t) so COP works correctly
  in both heating (Vorlauf > Rücklauf) and cooling (Vorlauf < Rücklauf) modes
- Add 150W minimum electrical power threshold for COP calculation to avoid
  meaningless values from idle/standby power consumption
- Add test for minimum power threshold (100W < 150W -> returns None)
- Add test for cooling mode with negative delta_t (external power sensor)
- Add test for cooling mode with negative delta_t (Modbus power data)