### PR TITLE
fix: resolve test collection errors for register_types and register_constants

### DIFF
--- a/custom_components/ha_daikin_altherma4_modbus/register_types.py
+++ b/custom_components/ha_daikin_altherma4_modbus/register_types.py
@@ -1,5 +1,7 @@
 """Register definition dataclasses for type-safe Modbus register handling."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 from homeassistant.const import EntityCategory

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,14 +120,27 @@ def load_register_constants_module(project_root):
     try:
         os.chdir(custom_components_parent)
 
-        # Import the module properly
+        # Import the modules properly
         import importlib.util
 
+        # First load register_types so register_constants' relative import works
+        register_types_spec = importlib.util.spec_from_file_location(
+            "ha_daikin_altherma4_modbus.register_types",
+            "ha_daikin_altherma4_modbus/register_types.py",
+        )
+        register_types_module = importlib.util.module_from_spec(register_types_spec)
+        sys.modules["ha_daikin_altherma4_modbus.register_types"] = register_types_module
+        register_types_spec.loader.exec_module(register_types_module)
+
+        # Now load register_constants which imports from .register_types
         spec = importlib.util.spec_from_file_location(
             "ha_daikin_altherma4_modbus.register_constants",
             "ha_daikin_altherma4_modbus/register_constants.py",
         )
         register_constants_module = importlib.util.module_from_spec(spec)
+        sys.modules["ha_daikin_altherma4_modbus.register_constants"] = (
+            register_constants_module
+        )
         spec.loader.exec_module(register_constants_module)
 
         return register_constants_module


### PR DESCRIPTION
## Summary

Fixes two test collection errors that were breaking the test suite.

### Issue 1: `TypeError: unsupported operand type(s) for |: 'Mock' and 'NoneType'`

**Root Cause:** In `register_types.py`, the dataclass field annotation `entity_category: EntityCategory | None = None` uses PEP 604 union syntax (`|`). This annotation is evaluated at class definition time. When tests run, `test_utils.py` mocks `homeassistant.const.EntityCategory` as a `Mock()` object. Since `Mock` doesn't support the `|` operator with `None`, the class definition fails.

**Fix:** Added `from __future__ import annotations` to `register_types.py` to make all type annotations lazy (stored as strings), preventing runtime evaluation of the `|` operator.

### Issue 2: `ModuleNotFoundError: No module named 'ha_daikin_altherma4_modbus.register_types'`

**Root Cause:** In `test_utils.py`, the `load_register_constants_module()` function loaded `register_constants.py` via `importlib.util.spec_from_file_location()`. The relative import `from .register_types import ...` in `register_constants.py` failed because `register_types` was never loaded into `sys.modules` as part of the package.

**Fix:** Updated `load_register_constants_module()` to first load `register_types.py` and register it in `sys.modules` before loading `register_constants.py`.

## Verification

- `tests/test_clean_coverage.py`: 10 tests pass
- `tests/test_last_triggered.py`: 10 tests pass
- Full test suite: **295 passed** with no regressions