### PR TITLE
fix: remove invalid speed device class on circulation pump speed sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ You can change the host address and port via the reconfigure flow:
 |--------|---------|------|-------------|------------|-------------|
 | Bypass valve position | 66 | % | – | measurement | – |
 | Storage valve position | 67 | % | – | measurement | – |
-| Circulation pump speed | 68 | % | speed | measurement | – |
+| Circulation pump speed | 68 | % | – | measurement | – |
 | Mixed pump PWM | 69 | % | – | measurement | – |
 | Direct pump PWM | 70 | % | – | measurement | – |
 | Mixing valve position | 71 | % | – | measurement | – |

--- a/custom_components/ha_daikin_altherma4_modbus/core/register_constants.py
+++ b/custom_components/ha_daikin_altherma4_modbus/core/register_constants.py
@@ -459,7 +459,6 @@ INPUT_REGISTERS = [
         register_name="input_68",
         data_type=INT16,
         unit="%",
-        device_class=SensorDeviceClass.SPEED,
         translation_key="input_68",
     ),
     SensorRegister(


### PR DESCRIPTION
The circulation pump speed value is a percentage/duty cycle, but device_class: speed only accepts physical speed units. This produced an invalid device_class/unit warning in HA and broke long-term statistics.